### PR TITLE
Clean dependencies and remove old packages

### DIFF
--- a/BookManagement.API/BookManagement.API.csproj
+++ b/BookManagement.API/BookManagement.API.csproj
@@ -17,11 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Unity" Version="5.11.10" />
-    <PackageReference Include="Unity.Mvc" Version="5.11.1" />
-    <PackageReference Include="Unity.WebAPI" Version="5.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BookManagement.API/Startup.cs
+++ b/BookManagement.API/Startup.cs
@@ -13,9 +13,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
-using Microsoft.Owin;
-
-[assembly: OwinStartup(typeof(Startup))]
 
 namespace BookManagement.API;
 

--- a/DataAccessLayer/DataAccessLayer.csproj
+++ b/DataAccessLayer/DataAccessLayer.csproj
@@ -7,9 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">


### PR DESCRIPTION
## Summary
- strip EF6 and ASP.NET Identity 2.2 dependencies
- drop Unity/Owin packages from API project
- remove Owin attribute from Startup

## Testing
- `dotnet build CRUD.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684989f14ffc8322b3ddca09a28e3a5a