### PR TITLE
Load secrets via environment variables

### DIFF
--- a/BookManagement.API/Startup.cs
+++ b/BookManagement.API/Startup.cs
@@ -36,8 +36,12 @@ public class Startup
 
 
 
+        var connectionString = Configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(connectionString))
+            connectionString = Environment.GetEnvironmentVariable("DEFAULT_CONNECTION");
+
         services.AddDbContext<LibraryDbContext>(options =>
-            options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+            options.UseSqlServer(connectionString));
 
         services.AddIdentity<IdentityUser, IdentityRole>()
             .AddEntityFrameworkStores<LibraryDbContext>().AddDefaultTokenProviders();
@@ -94,7 +98,10 @@ public class Startup
 
                     ValidIssuer = Configuration["Jwt:Issuer"],
                     ValidAudience = Configuration["Jwt:Issuer"],
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration["Jwt:Key"] ?? string.Empty))
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
+                        string.IsNullOrWhiteSpace(Configuration["Jwt:Key"])
+                            ? Environment.GetEnvironmentVariable("JWT_KEY") ?? string.Empty
+                            : Configuration["Jwt:Key"]))
                 };
             });
     }

--- a/BookManagement.API/appsettings.json
+++ b/BookManagement.API/appsettings.json
@@ -6,10 +6,10 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=DESKTOP-OK08180\\SQLEXPRESS;Database=Library;Trusted_Connection=True;TrustServerCertificate=true;MultipleActiveResultSets=true"
+    "DefaultConnection": ""
   },
   "Jwt": {
-    "Key": "ThisIsYourSecretKeyForJwt",
+    "Key": "",
     "Issuer": "your_issuer",
     "ExpireDays": "7"
   },


### PR DESCRIPTION
## Summary
- remove connection string and JWT secret from `appsettings.json`
- pull connection string and JWT key from environment variables in `Startup`

## Testing
- `dotnet build CRUD.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849aea2af94832293fe24e412848813